### PR TITLE
🚀[가게 추가 구현] Release

### DIFF
--- a/src/shop/dto/add-shop.args.ts
+++ b/src/shop/dto/add-shop.args.ts
@@ -39,7 +39,7 @@ export class AddShopArgs {
 
   @ArrayUnique()
   @IsEnum(DAY_OF_WEEK, { each: true })
-  @Field(() => DAY_OF_WEEK)
+  @Field(() => [DAY_OF_WEEK])
   offDay: DAY_OF_WEEK[];
 
   @IsNotEmpty()

--- a/src/shop/dto/add-shop.args.ts
+++ b/src/shop/dto/add-shop.args.ts
@@ -1,0 +1,74 @@
+import { ArgsType, Field, Int } from '@nestjs/graphql';
+import {
+  ArrayUnique,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+import { DAY_OF_WEEK } from '../../common/enum/day-of-week';
+
+@ArgsType()
+export class AddShopArgs {
+  @IsInt()
+  @Field(() => Int)
+  ownerId: number;
+
+  @IsNotEmpty()
+  @IsString()
+  @Field()
+  name: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Field()
+  branchName: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Field()
+  intro: string;
+
+  @ArrayUnique()
+  @IsString({ each: true })
+  @Field(() => [String])
+  imageUrls: string[];
+
+  @ArrayUnique()
+  @IsEnum(DAY_OF_WEEK, { each: true })
+  @Field(() => DAY_OF_WEEK)
+  offDay: DAY_OF_WEEK[];
+
+  @IsNotEmpty()
+  @IsString()
+  @Field()
+  address: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Field({ nullable: true })
+  latitude?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Field({ nullable: true })
+  longitude?: number;
+
+  @IsOptional()
+  @IsString({ each: true })
+  @Field(() => [String], { nullable: true })
+  additionalInfos?: string[];
+
+  @IsOptional()
+  @IsString()
+  @Field({ nullable: true })
+  locationDescription?: string;
+
+  @IsOptional()
+  @IsString()
+  @Field({ nullable: true })
+  safeNumber?: string;
+}

--- a/src/shop/entity/shop.entity.ts
+++ b/src/shop/entity/shop.entity.ts
@@ -45,13 +45,13 @@ export class Shop {
   @Column({ length: 255 })
   intro: string;
 
-  @Field({ nullable: true, description: '추가정보' })
+  @Field(() => [String], { nullable: true, description: '추가정보' })
   @Column('simple-array', { nullable: true })
-  additionalInfos?: string;
+  additionalInfos?: string[];
 
-  @Field({ description: '가게 이미지' })
+  @Field(() => [String], { description: '가게 이미지' })
   @Column('simple-array')
-  imageUrls: string;
+  imageUrls: string[];
 
   @Field(() => DAY_OF_WEEK, { description: '정기휴일' })
   @Column({ type: 'enum', enum: DAY_OF_WEEK })

--- a/src/shop/interface/add-shop.interface.ts
+++ b/src/shop/interface/add-shop.interface.ts
@@ -1,0 +1,16 @@
+import { DAY_OF_WEEK } from '../../common/enum/day-of-week';
+
+export interface IAddShop {
+  ownerId: number;
+  name: string;
+  branchName: string;
+  intro: string;
+  imageUrls: string[];
+  offDay: DAY_OF_WEEK[];
+  address: string;
+  latitude?: number;
+  longitude?: number;
+  additionalInfos?: string[];
+  locationDescription?: string;
+  safeNumber?: string;
+}

--- a/src/shop/repository/shop.repository.ts
+++ b/src/shop/repository/shop.repository.ts
@@ -1,0 +1,11 @@
+import { EntityRepository, Repository } from 'typeorm';
+
+import { Shop } from '../entity/shop.entity';
+import { IAddShop } from '../interface/add-shop.interface';
+
+@EntityRepository(Shop)
+export class ShopRepository extends Repository<Shop> {
+  async addShop(args: IAddShop) {
+    return this.save(this.create(args));
+  }
+}

--- a/src/shop/shop.module.ts
+++ b/src/shop/shop.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ShopRepository } from './repository/shop.repository';
 import { ShopResolver } from './shop.resolver';
 import { ShopService } from './shop.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([ShopRepository])],
   providers: [ShopResolver, ShopService],
+  exports: [ShopService],
 })
 export class ShopModule {}

--- a/src/shop/shop.resolver.ts
+++ b/src/shop/shop.resolver.ts
@@ -1,8 +1,18 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
 
+import { RequestInfo, Roles } from '../common/decorator';
+import { Role } from '../common/enum';
+import { IRequest } from '../common/interface';
+import { AddShopArgs } from './dto/add-shop.args';
 import { ShopService } from './shop.service';
 
 @Resolver()
 export class ShopResolver {
   constructor(private readonly shopService: ShopService) {}
+
+  @Roles(Role.USER)
+  @Mutation(() => Boolean)
+  async addShop(@Args() args: AddShopArgs, @RequestInfo() req: Required<IRequest>) {
+    return this.shopService.addShop({ ...args, ownerId: req.user.id });
+  }
 }

--- a/src/shop/shop.service.spec.ts
+++ b/src/shop/shop.service.spec.ts
@@ -1,19 +1,57 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { userData } from '../../test/data/user.data.mock';
+import { MockShopRepository } from '../../test/repository/shop.repository.mock';
+import { DAY_OF_WEEK } from '../common/enum/day-of-week';
+import { ShopRepository } from './repository/shop.repository';
 import { ShopService } from './shop.service';
 
 describe('ShopService', () => {
   let service: ShopService;
-
+  let shopRepository: ShopRepository;
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ShopService],
+      providers: [
+        ShopService,
+        {
+          provide: ShopRepository,
+          useValue: MockShopRepository(),
+        },
+      ],
     }).compile();
 
     service = module.get<ShopService>(ShopService);
+    shopRepository = module.get<ShopRepository>(ShopRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('addShop()', () => {
+    it('normal case', async () => {
+      // given
+      const args = {
+        ownerId: userData()[0].id,
+        name: '피릿가게',
+        branchName: '서울역지점',
+        intro: '반갑습니다 ^^.',
+        imageUrls: ['https://naver.com/image'],
+        offDay: [DAY_OF_WEEK.MONDAY],
+        address: '서울특별시 관악구',
+        latitude: 53.23232,
+        longitude: 35.63443,
+        additionalInfos: ['알바생 이쁨'],
+        locationDescription: '거기 골목 옆에서 좀 들어오면 있어요.',
+        safeNumber: '0505-1111-2222',
+      };
+      // when
+      const result = await service.addShop(args);
+
+      // then
+      expect(result).toEqual(true);
+      expect(shopRepository.addShop).toBeCalledTimes(1);
+      expect(shopRepository.addShop).toBeCalledWith(args);
+    });
   });
 });

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -1,4 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
+import { IAddShop } from './interface/add-shop.interface';
+import { ShopRepository } from './repository/shop.repository';
+
 @Injectable()
-export class ShopService {}
+export class ShopService {
+  constructor(private readonly shopRepository: ShopRepository) {}
+
+  async addShop(args: IAddShop) {
+    await this.shopRepository.addShop(args);
+    return true;
+  }
+}

--- a/test/data/shop.data.mock.ts
+++ b/test/data/shop.data.mock.ts
@@ -5,9 +5,7 @@ import { Shop } from '../../src/shop/entity/shop.entity';
 export const shopDataObject = [
   {
     id: 1,
-    email: 'pirit@kyojs.com',
-    password: '12345678',
-    name: 'pirit',
+    name: '피릿 헤어샵',
   },
 ];
 

--- a/test/data/shop.data.mock.ts
+++ b/test/data/shop.data.mock.ts
@@ -1,0 +1,14 @@
+import { plainToClass } from 'class-transformer';
+
+import { Shop } from '../../src/shop/entity/shop.entity';
+
+export const shopDataObject = [
+  {
+    id: 1,
+    email: 'pirit@kyojs.com',
+    password: '12345678',
+    name: 'pirit',
+  },
+];
+
+export const shopData = () => shopDataObject.map((obj) => plainToClass(Shop, obj));

--- a/test/repository/shop.repository.mock.ts
+++ b/test/repository/shop.repository.mock.ts
@@ -1,0 +1,5 @@
+import { shopData } from '../data/shop.data.mock';
+
+export const MockShopRepository = () => ({
+  addShop: jest.fn().mockResolvedValue(shopData()[0]),
+});


### PR DESCRIPTION
## 개요

- Notion Task URL : https://jeweled-tracker-24d.notion.site/18b7c49ff0624bc6b476831a0349f9b8
- 가게 추가 구현

## 상세

- 가게추가 구현입니다.

## 결과

<img width="679" alt="image" src="https://user-images.githubusercontent.com/39974627/192808909-7f022a76-6f8d-4868-ac58-3e0a7af40db7.png">

### Author 테스트 여부

- [ ] 테스트 제외
- [X] Local 테스트 완료
- [ ] Develop 테스트 완료

### 테스트 방법

- https://dev-hairshop.kyojs.com/graphql

### 체크리스트

- N/A
