### PR TITLE
[Blocked By #25]샵 좌석 조회 구현

### DIFF
--- a/src/seat/dto/shop-id.args.ts
+++ b/src/seat/dto/shop-id.args.ts
@@ -1,0 +1,10 @@
+import { ArgsType, Field, Int } from '@nestjs/graphql';
+import { IsInt, Min } from 'class-validator';
+
+@ArgsType()
+export class ShopIdArgs {
+  @IsInt()
+  @Min(1)
+  @Field(() => Int)
+  shopId: number;
+}

--- a/src/seat/repository/seat.repository.ts
+++ b/src/seat/repository/seat.repository.ts
@@ -5,6 +5,10 @@ import { IAddSeatWithInfo } from './interface/add-seat-with-info.interface';
 
 @EntityRepository(Seat)
 export class SeatRepository extends Repository<Seat> {
+  async getOneByShopId(shopId: number) {
+    return this.find({ shopId });
+  }
+
   async addSeat(args: IAddSeatWithInfo) {
     return this.save(this.create(args));
   }

--- a/src/seat/repository/seat.repository.ts
+++ b/src/seat/repository/seat.repository.ts
@@ -6,7 +6,7 @@ import { IAddSeatWithInfo } from './interface/add-seat-with-info.interface';
 @EntityRepository(Seat)
 export class SeatRepository extends Repository<Seat> {
   async getOneByShopId(shopId: number) {
-    return this.find({ shopId });
+    return this.findOne({ shopId });
   }
 
   async addSeat(args: IAddSeatWithInfo) {

--- a/src/seat/seat.resolver.ts
+++ b/src/seat/seat.resolver.ts
@@ -1,14 +1,21 @@
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
 import { RequestInfo, Roles } from '../common/decorator';
 import { Role } from '../common/enum';
 import { IRequest } from '../common/interface';
 import { AddSeatArgs } from './dto/add-seat.args';
+import { ShopIdArgs } from './dto/shop-id.args';
+import { Seat } from './entity/seat.entity';
 import { SeatService } from './seat.service';
 
 @Resolver()
 export class SeatResolver {
   constructor(private readonly seatService: SeatService) {}
+
+  @Query(() => Seat)
+  async seat(@Args() args: ShopIdArgs) {
+    return this.seatService.getSeatByShopId(args.shopId);
+  }
 
   @Roles(Role.USER)
   @Mutation(() => Boolean)

--- a/src/seat/seat.service.spec.ts
+++ b/src/seat/seat.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { seatData } from '../../test/data/seat.data.mock';
 import { MockSeatRepository } from '../../test/repository/seat.repository.mock';
 import { MockShopService } from '../../test/service/shop.service.mock';
 import { Exceptions } from '../common/exceptions';
@@ -34,6 +35,21 @@ describe('SeatService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getSeatByShopId', () => {
+    it('normal case', async () => {
+      // given
+      const shopId = 1;
+
+      // when
+      const result = await service.getSeatByShopId(shopId);
+
+      // then
+      expect(result).toEqual(seatData()[0]);
+      expect(seatRepository.getOneByShopId).toBeCalledTimes(1);
+      expect(seatRepository.getOneByShopId).toBeCalledWith(shopId);
+    });
   });
 
   describe('addSeat', () => {

--- a/src/seat/seat.service.ts
+++ b/src/seat/seat.service.ts
@@ -13,6 +13,10 @@ export class SeatService {
     private readonly shopService: ShopService,
   ) {}
 
+  async getSeatByShopId(shopId: number) {
+    return this.seatRepository.getOneByShopId(shopId);
+  }
+
   async addSeat(args: IAddSeat) {
     const { userId, shopId, seat } = args;
     const shop = await this.shopService.getShopById(shopId);

--- a/test/repository/seat.repository.mock.ts
+++ b/test/repository/seat.repository.mock.ts
@@ -1,5 +1,6 @@
 import { seatData } from '../data/seat.data.mock';
 
 export const MockSeatRepository = () => ({
+  getOneByShopId: jest.fn().mockResolvedValue(seatData()[0]),
   addSeat: jest.fn().mockResolvedValue(seatData()[0]),
 });


### PR DESCRIPTION
[Blocked By #25]
## 개요

- Notion Task URL : https://jeweled-tracker-24d.notion.site/ee2ff969ff8b4c6f80e656b93c29913c
- 샵 좌석 조회 구현

## 상세

- shopId로 샵의 좌석을 조회할 수 있습니다.

## 결과

<img width="339" alt="image" src="https://user-images.githubusercontent.com/39974627/193402067-78a4363d-4d12-4c7d-9ec1-0742a3c26097.png">

### Author 테스트 여부

- [ ] 테스트 제외
- [X] Local 테스트 완료
- [ ] Develop 테스트 완료

### 테스트 방법

- https://dev-hairshop.kyojs.com/graphql

### 체크리스트

- [X] shopId로 좌석상태 조회시에 정상적으로 조회되는지 확인합니다.
